### PR TITLE
Add folium 0.14.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,60 @@
-{% set version = "0.12.0" %}
+{% set name = "folium" %}
+{% set version = "0.14.0" %}
+
 
 package:
-  name: folium
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/f/folium/folium-{{ version }}.tar.gz
-  sha256: d45ace0a813ae65f202ce0356eb29c40a5e8fde071e4d6b5be0a89587ebaeab2
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/folium-{{ version }}.tar.gz
+  sha256: 8ec44697d18f5932e0fdaee8b19da98625de4d0e72cb30ef56f9479f18e11b9f
 
 build:
-  number: 1
-  noarch: python
-  script:
-    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
-    - {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: True  # [py<35]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
+    - setuptools_scm
+    - wheel
   run:
-    - python >=3.5
-    - branca >=0.3.0
+    - python
+    - branca >=0.6.0
     - jinja2 >=2.9
     - numpy
     - requests
 
 test:
+  imports:
+    - folium
   requires:
     - pip
   commands:
     - pip check
-  imports:
-    - folium
 
 about:
   home: https://github.com/python-visualization/folium
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
   summary: Make beautiful maps with Leaflet.js and Python
+  description: |
+    folium builds on the data wrangling strengths of the Python ecosystem 
+    and the mapping strengths of the leaflet.js library. 
+    Manipulate your data in Python, then visualize it in on a Leaflet map via folium.
+    folium makes it easy to visualize data that's been manipulated in Python on an interactive leaflet map. 
+    It enables both the binding of data to a map for choropleth visualizations 
+    as well as passing rich vector/raster/HTML visualizations as markers on the map.
+    The library has a number of built-in tilesets from OpenStreetMap, Mapbox, and Stamen, 
+    and supports custom tilesets with Mapbox or Cloudmade API keys. 
+    folium supports both Image, Video, GeoJSON and TopoJSON overlays.
+  doc_url: https://python-visualization.github.io/folium/
+  dev_url: https://github.com/python-visualization/folium
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - pip check
 
 about:
-  home: https://github.com/python-visualization/folium
+  home: https://python-visualization.github.io/folium/
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt


### PR DESCRIPTION
Changelog: https://github.com/python-visualization/folium/blob/v0.14.0/CHANGES.txt
License: https://github.com/python-visualization/folium/blob/v0.14.0/LICENSE.txt
Requirements:
- https://github.com/python-visualization/folium/blob/v0.14.0/pyproject.toml
- https://github.com/python-visualization/folium/blob/v0.14.0/requirements.txt
- https://github.com/python-visualization/folium/blob/a457a868ff17c109df170afa9c08b6c179b29d10/setup.py#L61

Actions:

- Remove `noarch`

- Skip `py<35`

- Add `--no-deps` to `script`

- Add missing `setuptools`, `setuptools_scm`, `wheel` to `host`

- Fix `python` in `host` and `run`

- Update `branca` pinning

- Add `license_family`

- Add `description`

- Add dev and doc urls

**_Notes_**

- folium depends on `branca` https://github.com/AnacondaRecipes/branca-feedstock/pull/3